### PR TITLE
Expand instance objects sqs_msg when notify exception

### DIFF
--- a/lib/exception_notification/shoryuken/shoryuken.rb
+++ b/lib/exception_notification/shoryuken/shoryuken.rb
@@ -8,7 +8,7 @@ module ExceptionNotification
         begin
           yield
         rescue Exception => exception
-          ExceptionNotifier.notify_exception(exception, :data => { :sqs_msg => sqs_msg })
+          ExceptionNotifier.notify_exception(exception, :data => { :sqs_msg => sqs_msg.inspect })
           raise exception
         end
       end


### PR DESCRIPTION
When I catch exception,
<img width="864" alt="2016-06-24 15 40 17" src="https://cloud.githubusercontent.com/assets/4631959/16330122/faa62c80-3a21-11e6-8f58-de8556f79ec7.png">

I can not see message body. So, I can not figure out why exception happens.
We can see the message body in AWS Management console, but we can catch only dead letter message. If shoryuken retry the message, we can not see this message.

I want to see message body with exception report.
