### PR TITLE
Update deps to shoryuken 4.0

### DIFF
--- a/exception_notification-shoryuken.gemspec
+++ b/exception_notification-shoryuken.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'exception_notification', "~> 4"
-  spec.add_runtime_dependency 'shoryuken', "~> 3.0"
+  spec.add_runtime_dependency 'shoryuken', "~> 4.0"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
The version will probably need to be bumped as well. Should that be included in the PR?